### PR TITLE
Update to latest brokerapi.

### DIFF
--- a/efsbroker/efsbroker.go
+++ b/efsbroker/efsbroker.go
@@ -229,7 +229,14 @@ func (b *Broker) Bind(context context.Context, instanceID string, bindingID stri
 		return brokerapi.Binding{}, brokerapi.ErrAppGuidNotProvided
 	}
 
-	mode, err := evaluateMode(details.Parameters)
+	var params map[string]interface{}
+	if len(details.RawParameters) > 0 {
+		if err := json.Unmarshal(details.RawParameters, &params); err != nil {
+			return brokerapi.Binding{}, err
+		}
+	}
+
+	mode, err := evaluateMode(params)
 	if err != nil {
 		return brokerapi.Binding{}, err
 	}
@@ -252,7 +259,7 @@ func (b *Broker) Bind(context context.Context, instanceID string, bindingID stri
 	return brokerapi.Binding{
 		Credentials: struct{}{}, // if nil, cloud controller chokes on response
 		VolumeMounts: []brokerapi.VolumeMount{{
-			ContainerDir: evaluateContainerPath(details.Parameters, instanceID),
+			ContainerDir: evaluateContainerPath(params, instanceID),
 			Mode:         mode,
 			Driver:       "efsdriver",
 			DeviceType:   "shared",

--- a/efsbroker/efsbroker_test.go
+++ b/efsbroker/efsbroker_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Broker", func() {
 
 				broker.ProvisionEvent(&opState)
 
-				bindDetails = brokerapi.BindDetails{AppGUID: "guid", Parameters: map[string]interface{}{}}
+				bindDetails = brokerapi.BindDetails{AppGUID: "guid"}
 			})
 
 			It("includes empty credentials to prevent CAPI crash", func() {
@@ -371,7 +371,10 @@ var _ = Describe("Broker", func() {
 			})
 
 			It("flows container path through", func() {
-				bindDetails.Parameters["mount"] = "/var/vcap/otherdir/something"
+				var err error
+				params := map[string]interface{}{"mount": "/var/vcap/otherdir/something"}
+				bindDetails.RawParameters, err = json.Marshal(params)
+				Expect(err).NotTo(HaveOccurred())
 				binding, err := broker.Bind(ctx, instanceID, bindingID, bindDetails)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(binding.VolumeMounts[0].ContainerDir).To(Equal("/var/vcap/otherdir/something"))
@@ -384,7 +387,10 @@ var _ = Describe("Broker", func() {
 			})
 
 			It("sets mode to `r` when readonly is true", func() {
-				bindDetails.Parameters["readonly"] = true
+				var err error
+				params := map[string]interface{}{"readonly": true}
+				bindDetails.RawParameters, err = json.Marshal(params)
+				Expect(err).NotTo(HaveOccurred())
 				binding, err := broker.Bind(ctx, instanceID, bindingID, bindDetails)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -408,8 +414,11 @@ var _ = Describe("Broker", func() {
 			})
 
 			It("errors if mode is not a boolean", func() {
-				bindDetails.Parameters["readonly"] = ""
-				_, err := broker.Bind(ctx, instanceID, bindingID, bindDetails)
+				var err error
+				params := map[string]interface{}{"readonly": "true"}
+				bindDetails.RawParameters, err = json.Marshal(params)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = broker.Bind(ctx, instanceID, bindingID, bindDetails)
 				Expect(err).To(Equal(brokerapi.ErrRawParamsInvalid))
 			})
 
@@ -645,7 +654,7 @@ var _ = Describe("Broker", func() {
 				},
 			)
 
-			_, err = broker.Bind(ctx, serviceName, "whatever", brokerapi.BindDetails{AppGUID: "guid", Parameters: map[string]interface{}{}})
+			_, err = broker.Bind(ctx, serviceName, "whatever", brokerapi.BindDetails{AppGUID: "guid"})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -671,7 +680,7 @@ var _ = Describe("Broker", func() {
 				},
 			)
 
-			_, err := broker.Bind(ctx, serviceName, "whatever", brokerapi.BindDetails{AppGUID: "guid", Parameters: map[string]interface{}{}})
+			_, err := broker.Bind(ctx, serviceName, "whatever", brokerapi.BindDetails{AppGUID: "guid"})
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Same as https://github.com/cloudfoundry/nfsbroker/pull/3; `go install code.cloudfoundry.org/efsbroker/cmd/efsbroker` fails on current brokerapi.